### PR TITLE
support and document passing a style object to inspect instead of choosing a preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ It just counts the number of *format specifier* in the `formatString`.
 		* 'none': (default) normal output suitable for console.log() or writing into a file
 		* 'color': colorful output suitable for terminal
 		* 'html': html output
+		* for more control, an object can be passed, see [inspect.js](https://github.com/cronvel/string-kit/blob/6df4842423d1318e475f7a38142bcd356afd8c0f/lib/inspect.js#L488-L560)
 	* depth: depth limit, default: 3
 	* noFunc: do not display functions
 	* noDescriptor: do not display descriptor information

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -72,7 +72,7 @@ function inspect( options , variable )
 	
 	if ( ! options.style ) { options.style = inspectStyle.none ; }
 	else if ( typeof options.style === 'string' ) { options.style = inspectStyle[ options.style ] ; }
-	
+	else {options.style = Object.assign({}, inspectStyle.none, options.style)}
 	if ( options.depth === undefined ) { options.depth = 3 ; }
 	
 	// /!\ nofunc is deprecated

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -72,7 +72,7 @@ function inspect( options , variable )
 	
 	if ( ! options.style ) { options.style = inspectStyle.none ; }
 	else if ( typeof options.style === 'string' ) { options.style = inspectStyle[ options.style ] ; }
-	else {options.style = Object.assign({}, inspectStyle.none, options.style)}
+	else { options.style = Object.assign({}, inspectStyle.none, options.style) ; }
 	if ( options.depth === undefined ) { options.depth = 3 ; }
 	
 	// /!\ nofunc is deprecated


### PR DESCRIPTION
This was already sort of supported, but without defaulting to the "none" inspect style, it's not very convenient. In my case, I just needed to adjust the tab setting from 4 spaces to 2.