### PR TITLE
fix: Replace unsupported syntax for Node 6

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -621,7 +621,7 @@ function metricPrefix( n ) {
 		log = Math.floor( Math.log10( n ) ) ;
 		logDiv3 = Math.floor( log / 3 ) ;
 		logMod = log % 3 ;
-		base = round( n / ( 1000 ** logDiv3 ) , roundStep[ logMod ] ) ;
+		base = round( n / ( Math.pow( 1000, logDiv3 ) ) , roundStep[ logMod ] ) ;
 		prefix = mulPrefix[ logDiv3 ] ;
 	}
 	else {
@@ -629,7 +629,7 @@ function metricPrefix( n ) {
 		logDiv3 = Math.floor( log / 3 ) ;
 		logMod = log % 3 ;
 		if ( logMod < 0 ) { logMod += 3 ; }
-		base = round( n / ( 1000 ** logDiv3 ) , roundStep[ logMod ] ) ;
+		base = round( n / ( Math.pow( 1000, logDiv3 ) ) , roundStep[ logMod ] ) ;
 		prefix = subMulPrefix[ -logDiv3 ] ;
 	}
 


### PR DESCRIPTION
Since Node 6 is an officially supported engine, using the experimental exponential operator is a bug.